### PR TITLE
Features/aut 91 new ablockcall

### DIFF
--- a/api_objects/api_objects_factomd.py
+++ b/api_objects/api_objects_factomd.py
@@ -278,14 +278,13 @@ class APIObjectsFactomd():
         :return: fblock dict
         '''
         blocks = json.loads(self.send_get_request_with_params_dict('factoid-block', {'KeyMR': keymr})[0])
-        print blocks
         return blocks['result']['fblock']
 
     def get_entrycredit_block_by_keymr(self, keymr):
         '''
         Get factoid block by keymr
         :param keymr: keymr
-        :return: fblock dict
+        :return: ecblock dict
         '''
         blocks = json.loads(self.send_get_request_with_params_dict('entrycredit-block', {'KeyMR': keymr})[0])
         return blocks['result']['ecblock']
@@ -295,8 +294,7 @@ class APIObjectsFactomd():
         '''
         Get factoid block by keymr
         :param keymr: keymr
-        :return: fblock dict
+        :return: ablock dict
         '''
         blocks = json.loads(self.send_get_request_with_params_dict('admin-block', {'KeyMR': keymr})[0])
-
         return blocks['result']['ablock']

--- a/api_tests/api_tests_heights.py
+++ b/api_tests/api_tests_heights.py
@@ -127,6 +127,6 @@ class APITestsHeights(unittest.TestCase):
                                 "mismatch in call to admin block keymr at height %d" % (x))
 
                 self.api.change_factomd_address(factomd_address_custom)
-                ablock_keymr_result_1 = self.api.get_factoid_block_by_keymr(ablock_keymr)
+                ablock_keymr_result_1 = self.api.get_admin_block_by_keymr(ablock_keymr)
                 self.assertTrue(ablock_keymr_result == ablock_keymr_result_1,
                                 "mismatch in admin block keymr at height %d" % (x))


### PR DESCRIPTION
A new API call for admin , entrycredit and factoid block is added which takes keymr as input 
the test case compares the output with height output and also compares with all nodes in ansible.