### PR TITLE
Updated identity tests to support recent API changes

### DIFF
--- a/api_objects/api_objects_wallet.py
+++ b/api_objects/api_objects_wallet.py
@@ -321,14 +321,14 @@ class APIObjectsWallet():
         block = json.loads(self.send_post_request_with_params_dict('import-identity-key',{'public': secretkey}))
         return block['result']
 
-    def identity_key_at_height(self,chainid,height):
+    def active_identity_keys(self,chainid,height):
         '''
-        This command will return the valid public keys for an identity at a given point in time.
+        This command will return the active public keys for an identity at a given point in time.
         Time is indicated by the block height of the Factom blockchain at the desired time.
         Input: chainid, height
         Output: set of four public keys
         '''
-        block = json.loads(self.send_post_request_with_params_dict('identity-keys-at-height', {'chainid': chainid,'height': height}))
+        block = json.loads(self.send_post_request_with_params_dict('active-identity-keys', {'chainid': chainid,'height': height}))
         return block['result']
 
 

--- a/api_tests/api_tests_wallet_identity.py
+++ b/api_tests/api_tests_wallet_identity.py
@@ -117,8 +117,8 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         # reveal chain
         reveal = self.api_factomd.reveal_chain(compose['reveal']['params']['entry'])
 
-        chain_external_ids.insert(0, '-n')
-        chain_external_ids.insert(2, '-n')
+        chain_external_ids.insert(0, 'IdentityChain')
+        chain_external_ids = [v for ext_id in chain_external_ids for v in ('-n', ext_id)]
 
         # search for revealed chain
         status = wait_for_chain_in_block(external_id_list=chain_external_ids)
@@ -153,8 +153,8 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         # reveal chain
         reveal = self.api_factomd.reveal_chain(compose['reveal']['params']['entry'])
 
-        chain_external_ids.insert(0, '-n')
-        chain_external_ids.insert(2, '-n')
+        chain_external_ids.insert(0, 'IdentityChain')
+        chain_external_ids = [v for ext_id in chain_external_ids for v in ('-n', ext_id)]
 
         # search for revealed chain
         status = wait_for_chain_in_block(external_id_list=chain_external_ids)
@@ -169,7 +169,7 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         self.assertTrue('DBlockConfirmed' in str(self.api_factomd.get_status(reveal['entryhash'], reveal['chainid'])),
                         'Chain not arrived in block')
 
-    def test_identity_key_at_height(self):
+    def test_active_identity_keys(self):
         '''
         Test to fetch the identity keys of identity chain at a specific height
         :return:
@@ -189,8 +189,10 @@ class ApiTestsWalletIdentity(unittest.TestCase):
 
         # reveal chain
         reveal = self.api_factomd.reveal_chain(compose['reveal']['params']['entry'])
-        chain_external_ids.insert(0, '-n')
-        chain_external_ids.insert(2, '-n')
+        
+        chain_external_ids.insert(0, 'IdentityChain')
+        chain_external_ids = [v for ext_id in chain_external_ids for v in ('-n', ext_id)]
+
         status = wait_for_chain_in_block(external_id_list=chain_external_ids)
 
 
@@ -202,7 +204,7 @@ class ApiTestsWalletIdentity(unittest.TestCase):
 
         height = self.api_factomd.get_heights()
 
-        result = self.api_wallet.identity_key_at_height(reveal['chainid'], height['directoryblockheight'])
+        result = self.api_wallet.active_identity_keys(reveal['chainid'], height['directoryblockheight'])
         self.assertTrue(keylist == result['keys'],"Found the key. Testcase Passed")
 
 
@@ -227,8 +229,8 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         reveal = self.api_factomd.reveal_chain(compose['reveal']['params']['entry'])
 
         #wait until chain is written into the blockchain
-        chain_external_ids.insert(0, '-n')
-        chain_external_ids.insert(2, '-n')
+        chain_external_ids.insert(0, 'IdentityChain')
+        chain_external_ids = [v for ext_id in chain_external_ids for v in ('-n', ext_id)]
 
         status = wait_for_chain_in_block(external_id_list=chain_external_ids)
 
@@ -263,7 +265,7 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         height = self.api_factomd.get_heights()
 
         #get the identity keys of the chain
-        result = self.api_wallet.identity_key_at_height(reveal['chainid'], height['directoryblockheight'])
+        result = self.api_wallet.active_identity_keys(reveal['chainid'], height['directoryblockheight'])
 
         #compare the identity keys before replacing and after replacing. If they are same then test case failed else test case passed
         self.assertNotEqual(keylist, result['keys'], "Key Found. Testcase Failed")
@@ -320,8 +322,8 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         receiver_chainid= reveal['chainid']
 
         # wait until chain is written into the blockchain
-        chain_external_ids.insert(0, '-n')
-        chain_external_ids.insert(2, '-n')
+        chain_external_ids.insert(0, 'IdentityChain')
+        chain_external_ids = [v for ext_id in chain_external_ids for v in ('-n', ext_id)]
 
         status = wait_for_chain_in_block(external_id_list=chain_external_ids)
 
@@ -370,7 +372,7 @@ class ApiTestsWalletIdentity(unittest.TestCase):
         height = self.api_factomd.get_heights()
 
         # get the identity keys of the chain
-        result = self.api_wallet.identity_key_at_height(receiver_chainid, height['directoryblockheight'])
+        result = self.api_wallet.active_identity_keys(receiver_chainid, height['directoryblockheight'])
         signer_key = result['keys'][0]
 
         #compose entry for attribute endorsement

--- a/cli_objects/cli_objects_identity_wallet.py
+++ b/cli_objects/cli_objects_identity_wallet.py
@@ -10,7 +10,8 @@ class CLIObjectsIdentityWallet(CLIObjectsBase):
     _new_identity = "newidentitykey "
     _list_identity_keys = "listidentitykeys "
     _rm_identity_key = "rmidentitykey "
-    _identity_get_height = "identity getkeysatheight "
+    _identity_get_active_keys = "identity getactivekeys "
+    _identity_get_active_keys_at_height = "identity getactivekeysatheight "
     _identity_key_replacement = "identity addkeyreplacement "
 
 
@@ -62,8 +63,11 @@ class CLIObjectsIdentityWallet(CLIObjectsBase):
                                                              , ' -attribute ', attribute, ' ',  ecaddress)))
 
 
-    def get_keys_at_height(self,chainid, height):
-        return send_command_to_cli_and_receive_text(''.join((self._cli_command, self._identity_get_height, ' -c ', chainid, ' ' , height)))
+    def get_active_keys(self,chainid):
+        return send_command_to_cli_and_receive_text(''.join((self._cli_command, self._identity_get_active_keys, ' -c ', chainid)))
+
+    def get_active_keys_at_height(self,chainid, height):
+        return send_command_to_cli_and_receive_text(''.join((self._cli_command, self._identity_get_active_keys_at_height, ' -c ', chainid, ' ' , height)))
 
 
 

--- a/cli_tests/cli_tests_identity_wallet.py
+++ b/cli_tests/cli_tests_identity_wallet.py
@@ -104,7 +104,7 @@ class CLITestsChains(unittest.TestCase):
         self.entry_credit_address100 = fund_entry_credit_address(100)
         self.heights =  self.cli_chain.get_heights()
         directory_block_height = self.cli_chain.parse_transaction_data(self.heights)['DirectoryBlockHeight']
-        self.keys = self.cli_identity.get_keys_at_height(receiver_chainid,directory_block_height)
+        self.keys = self.cli_identity.get_active_keys_at_height(receiver_chainid,directory_block_height)
         signerkey = self.cli_chain.parse_keys_data(self.keys,0)
         signer_chainid = receiver_chainid
         attributes = "\'[{\"key\": \"email\", \"value\": \"veena@abc.com\"}]\'"
@@ -131,7 +131,7 @@ class CLITestsChains(unittest.TestCase):
         self.entry_credit_address100 = fund_entry_credit_address(100)
         self.heights =  self.cli_chain.get_heights()
         directory_block_height = self.cli_chain.parse_transaction_data(self.heights)['DirectoryBlockHeight']
-        self.keys = self.cli_identity.get_keys_at_height(receiver_chainid,directory_block_height)
+        self.keys = self.cli_identity.get_active_keys_at_height(receiver_chainid,directory_block_height)
         signerkey = self.cli_chain.parse_keys_data(self.keys,0)
         signer_chainid = receiver_chainid
         attributes = "\'[{\"key\": \"email\", \"value\": \"veena@abc.com\"}]\'"
@@ -163,7 +163,7 @@ class CLITestsChains(unittest.TestCase):
         # fetch the height and keys of the chain id
         self.heights =  self.cli_chain.get_heights()
         directory_block_height = self.cli_chain.parse_transaction_data(self.heights)['DirectoryBlockHeight']
-        keys = self.cli_identity.get_keys_at_height(chainid,directory_block_height)
+        keys = self.cli_identity.get_active_keys_at_height(chainid,directory_block_height)
         signerkey = self.cli_chain.parse_keys_data(keys,0)
         oldkey = self.cli_chain.parse_keys_data(keys,2)
 
@@ -179,7 +179,7 @@ class CLITestsChains(unittest.TestCase):
         # fetch the height and keys of the chain id
         heights = self.cli_chain.get_heights()
         directory_block_height = self.cli_chain.parse_transaction_data(heights)['DirectoryBlockHeight']
-        new_key_list = self.cli_identity.get_keys_at_height(chainid, directory_block_height)
+        new_key_list = self.cli_identity.get_active_keys_at_height(chainid, directory_block_height)
 
         # fetch the key list and add it to the parsed key list
         parsed_key_list = []


### PR DESCRIPTION
Changes accommodated:
- "IdentityChain" ExtID flag at the beginning of every identity chain
- the "get-active-keys" call (refactored from old "identity-keys-at-height" call)